### PR TITLE
Fix Entra vars naming

### DIFF
--- a/r-vpn.tf
+++ b/r-vpn.tf
@@ -71,9 +71,9 @@ resource "azurerm_virtual_network_gateway" "main" {
 
     content {
       address_space = vpn.value.address_space
-      aad_tenant    = vpn.value.aad_tenant
-      aad_audience  = vpn.value.aad_audience
-      aad_issuer    = vpn.value.aad_issuer
+      aad_tenant    = vpn.value.entra_tenant
+      aad_audience  = vpn.value.entra_audience
+      aad_issuer    = vpn.value.entra_issuer
 
       dynamic "root_certificate" {
         for_each = vpn.value.root_certificate


### PR DESCRIPTION
Fixes #3  .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes proposed in this pull request

- Fix variables naming in [VPN resource code](https://github.com/claranet/terraform-azurerm-vpn/blob/master/r-vpn.tf#L74-L76) to fit [variables for VPN](https://github.com/claranet/terraform-azurerm-vpn/blob/master/variables-vpn.tf#L151-L153) in `vpn_client_configuration` block

@claranet/fr-azure-reviewers
